### PR TITLE
fix(net): make HdrGso an enum instead of a flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,15 @@ virtio_bitflags! {
 }
 
 /// Virtio Device IDs
+///
+/// <div class="warning">
+///
+/// This enum is not ABI-compatible with it's corresponding field.
+/// Use [`Id::from`] for converting from an integer.
+///
+/// </div>
+///
+/// [`Id::from`]: Id#impl-From<u8>-for-Id
 #[derive(IntoPrimitive, FromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]

--- a/src/net.rs
+++ b/src/net.rs
@@ -78,6 +78,15 @@ virtio_bitflags! {
 }
 
 /// Network Device Header GSO Type
+///
+/// <div class="warning">
+///
+/// This enum is not ABI-compatible with it's corresponding field.
+/// Use [`HdrGso::from`] for converting from an integer.
+///
+/// </div>
+///
+/// [`HdrGso::from`]: HdrGso#impl-From<u8>-for-HdrGso
 #[doc(alias = "VIRTIO_NET_HDR_GSO")]
 #[derive(IntoPrimitive, FromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -186,6 +195,15 @@ endian_bitflags! {
 }
 
 /// Hash Report
+///
+/// <div class="warning">
+///
+/// This enum is not ABI-compatible with it's corresponding field.
+/// Use [`HashReport::from`] for converting from an integer.
+///
+/// </div>
+///
+/// [`HashReport::from`]: HashReport#impl-From<u16>-for-HashReport
 #[doc(alias = "VIRTIO_NET_HASH_REPORT")]
 #[derive(IntoPrimitive, FromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
 #[non_exhaustive]

--- a/src/net.rs
+++ b/src/net.rs
@@ -77,28 +77,32 @@ virtio_bitflags! {
     }
 }
 
-virtio_bitflags! {
-    /// Network Device Header GSO Type
-    #[doc(alias = "VIRTIO_NET_HDR_GSO")]
-    pub struct HdrGso: u8 {
-        #[doc(alias = "VIRTIO_NET_HDR_GSO_NONE")]
-        const NONE = 0;
+/// Network Device Header GSO Type
+#[doc(alias = "VIRTIO_NET_HDR_GSO")]
+#[derive(IntoPrimitive, FromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum HdrGso {
+    #[doc(alias = "VIRTIO_NET_HDR_GSO_NONE")]
+    None = 0,
 
-        #[doc(alias = "VIRTIO_NET_HDR_GSO_TCPV4")]
-        const TCPV4 = 1;
+    #[doc(alias = "VIRTIO_NET_HDR_GSO_TCPV4")]
+    Tcpv4 = 1,
 
-        #[doc(alias = "VIRTIO_NET_HDR_GSO_UDP")]
-        const UDP = 3;
+    #[doc(alias = "VIRTIO_NET_HDR_GSO_UDP")]
+    Udp = 3,
 
-        #[doc(alias = "VIRTIO_NET_HDR_GSO_TCPV6")]
-        const TCPV6 = 4;
+    #[doc(alias = "VIRTIO_NET_HDR_GSO_TCPV6")]
+    Tcpv6 = 4,
 
-        #[doc(alias = "VIRTIO_NET_HDR_GSO_UDP_L4")]
-        const UDP_L4 = 5;
+    #[doc(alias = "VIRTIO_NET_HDR_GSO_UDP_L4")]
+    UdpL4 = 5,
 
-        #[doc(alias = "VIRTIO_NET_HDR_GSO_ECN")]
-        const ECN = 0x80;
-    }
+    #[doc(alias = "VIRTIO_NET_HDR_GSO_ECN")]
+    Ecn = 0x80,
+
+    #[num_enum(catch_all)]
+    Unknown(u8),
 }
 
 /// Network Device Header
@@ -116,7 +120,7 @@ virtio_bitflags! {
 #[repr(C)]
 pub struct Hdr {
     pub flags: HdrF,
-    pub gso_type: HdrGso,
+    pub gso_type: u8,
     pub hdr_len: le16,
     pub gso_size: le16,
     pub csum_start: le16,

--- a/src/pci.rs
+++ b/src/pci.rs
@@ -270,6 +270,15 @@ impl CapData {
 }
 
 /// PCI Capability Configuration Type
+///
+/// <div class="warning">
+///
+/// This enum is not ABI-compatible with it's corresponding field.
+/// Use [`CapCfgType::from`] for converting from an integer.
+///
+/// </div>
+///
+/// [`CapCfgType::from`]: CapCfgType#impl-From<u8>-for-CapCfgType
 #[doc(alias = "VIRTIO_PCI_CAP")]
 #[derive(IntoPrimitive, FromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
 #[non_exhaustive]


### PR DESCRIPTION
When discussing https://github.com/rust-osdev/virtio-spec-rs/pull/1 with @stlankes, we found that `HdrGso` should be an enum instead of a flag.