### PR TITLE
feat: add traditional mem balloon device

### DIFF
--- a/src/balloon.rs
+++ b/src/balloon.rs
@@ -1,0 +1,33 @@
+use volatile::access::{ReadOnly, ReadWrite};
+use volatile_macro::VolatileFieldAccess;
+
+pub use super::features::balloon::F;
+use crate::le32;
+
+/// Traditional Memory Balloon Device Configuration Layout
+///
+/// Use [`ConfigVolatileFieldAccess`] to work with this struct.
+#[doc(alias = "virtio_balloon_config")]
+#[cfg_attr(
+    feature = "zerocopy",
+    derive(
+        zerocopy_derive::KnownLayout,
+        zerocopy_derive::Immutable,
+        zerocopy_derive::FromBytes,
+    )
+)]
+#[derive(VolatileFieldAccess)]
+#[repr(C)]
+pub struct Config {
+    #[access(ReadOnly)] // TODO: Not actually specified by the spec?
+    num_pages: le32,
+
+    #[access(ReadWrite)]
+    actual: le32,
+
+    #[access(ReadOnly)]
+    free_page_hint_cmd_id: le32,
+
+    #[access(ReadWrite)]
+    poison_val: le32,
+}

--- a/src/features.rs
+++ b/src/features.rs
@@ -496,6 +496,51 @@ pub mod vsock {
     impl crate::FeatureBits for F {}
 }
 
+pub mod balloon {
+    use crate::le128;
+
+    feature_bits! {
+        /// Traditional Memory Balloon Device Feature Bits
+        #[doc(alias = "VIRTIO_BALLOON_F")]
+        pub struct F: le128 {
+            /// Host has to be told before pages from the balloon are used.
+            #[doc(alias = "VIRTIO_BALLOON_F_MUST_TELL_HOST")]
+            const MUST_TELL_HOST = 1 << 0;
+
+            /// A virtqueue for reporting guest memory statistics is present.
+            #[doc(alias = "VIRTIO_BALLOON_F_STATS_VQ")]
+            const STATS_VQ = 1 << 1;
+
+            /// Deflate of the balloon is always? permitted on guest out of memory condition.
+            ///
+            /// TODO: Spec is a bit confusing on this feature, see https://github.com/oasis-tcs/virtio-spec/issues/228
+            #[doc(alias = "VIRTIO_BALLOON_F_DEFLATE_ON_OOM")]
+            const DEFLATE_ON_OOM = 1 << 2;
+
+            /// The device has support for free page hinting.
+            /// A virtqueue for providing hints as to what memory is currently free is present.
+            /// Configuration field [`free_page_hint_cmd_id`](`crate::balloon::Config::free_page_hint_cmd_id`) is valid.
+            #[doc(alias = "VIRTIO_BALLOON_F_FREE_PAGE_HINT")]
+            const FREE_PAGE_HINT = 1 << 3;
+
+            /// A hint to the device, that the driver will immediately write
+            /// [`poison_val`] to pages after deflating them.
+            /// Configuration field [`poison_val`] is valid.
+            ///
+            /// [`poison_val`]: crate::balloon::Config::poison_val
+            #[doc(alias = "VIRTIO_BALLOON_F_PAGE_POISON")]
+            const PAGE_POISON = 1 << 4;
+
+            /// The device has support for free page reporting.
+            /// A virtqueue for reporting free guest memory is present.
+            #[doc(alias = "VIRTIO_BALLOON_F_PAGE_REPORTING")]
+            const PAGE_REPORTING = 1 << 5;
+        }
+    }
+
+    impl crate::FeatureBits for F {}
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,27 +61,27 @@
 //!
 //! ## Device Types
 //!
-//! | Device Type                       | Available | Module    |
-//! | --------------------------------- | --------- | --------- |
-//! | Network Device                    | ✅        | [`net`]   |
-//! | Block Device                      | ❌        |           |
-//! | Console Device                    | ❌        |           |
-//! | Entropy Device                    | ❌        |           |
-//! | Traditional Memory Balloon Device | ❌        |           |
-//! | SCSI Host Device                  | ❌        |           |
-//! | GPU Device                        | ❌        |           |
-//! | Input Device                      | ❌        |           |
-//! | Crypto Device                     | ❌        |           |
-//! | Socket Device                     | ✅        | [`vsock`] |
-//! | File System Device                | ✅        | [`fs`]    |
-//! | RPMB Device                       | ❌        |           |
-//! | IOMMU Device                      | ❌        |           |
-//! | Sound Device                      | ❌        |           |
-//! | Memory Device                     | ❌        |           |
-//! | I2C Adapter Device                | ❌        |           |
-//! | SCMI Device                       | ❌        |           |
-//! | GPIO Device                       | ❌        |           |
-//! | PMEM Device                       | ❌        |           |
+//! | Device Type                       | Available | Module      |
+//! | --------------------------------- | --------- | ----------- |
+//! | Network Device                    | ✅        | [`net`]     |
+//! | Block Device                      | ❌        |             |
+//! | Console Device                    | ❌        |             |
+//! | Entropy Device                    | ❌        |             |
+//! | Traditional Memory Balloon Device | ✅        | [`balloon`] |
+//! | SCSI Host Device                  | ❌        |             |
+//! | GPU Device                        | ❌        |             |
+//! | Input Device                      | ❌        |             |
+//! | Crypto Device                     | ❌        |             |
+//! | Socket Device                     | ✅        | [`vsock`]   |
+//! | File System Device                | ✅        | [`fs`]      |
+//! | RPMB Device                       | ❌        |             |
+//! | IOMMU Device                      | ❌        |             |
+//! | Sound Device                      | ❌        |             |
+//! | Memory Device                     | ❌        |             |
+//! | I2C Adapter Device                | ❌        |             |
+//! | SCMI Device                       | ❌        |             |
+//! | GPIO Device                       | ❌        |             |
+//! | PMEM Device                       | ❌        |             |
 
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
@@ -94,6 +94,7 @@ extern crate alloc;
 mod bitflags;
 #[macro_use]
 pub mod volatile;
+pub mod balloon;
 #[cfg(any(feature = "mmio", feature = "pci"))]
 mod driver_notifications;
 mod features;


### PR DESCRIPTION
Add the Traditional Memory Balloon Device based on [VIRTIO v1.2](https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.html)