### PR TITLE
feat(features): remove `FeatureBits` bounds that are not elaborated and seal `FeatureBits`

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -4,10 +4,8 @@ use crate::le128;
 
 /// Feature Bits
 #[doc(alias = "VIRTIO_F")]
-pub trait FeatureBits: bitflags::Flags<Bits = le128>
-where
-    Self: From<F> + AsRef<F> + AsMut<F>,
-    F: From<Self> + AsRef<Self> + AsMut<Self>,
+pub trait FeatureBits:
+    bitflags::Flags<Bits = le128> + From<F> + Into<F> + AsRef<F> + AsMut<F>
 {
     /// Returns the feature that this feature requires.
     ///

--- a/src/features.rs
+++ b/src/features.rs
@@ -1,11 +1,12 @@
 //! Feature Bits
 
 use crate::le128;
+use crate::sealed::Sealed;
 
 /// Feature Bits
 #[doc(alias = "VIRTIO_F")]
 pub trait FeatureBits:
-    bitflags::Flags<Bits = le128> + From<F> + Into<F> + AsRef<F> + AsMut<F>
+    bitflags::Flags<Bits = le128> + From<F> + Into<F> + AsRef<F> + AsMut<F> + Sealed
 {
     /// Returns the feature that this feature requires.
     ///
@@ -238,6 +239,8 @@ impl AsMut<F> for F {
 
 impl FeatureBits for F {}
 
+impl Sealed for F {}
+
 macro_rules! feature_bits {
     (
         $(#[$outer:meta])*
@@ -331,6 +334,8 @@ macro_rules! feature_bits {
                 unsafe { &mut *(self as *mut Self as *mut $crate::F) }
             }
         }
+
+        impl $crate::sealed::Sealed for $BitFlags {}
 
         feature_bits! {
             $($t)*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,10 @@ pub mod pvirtq;
 pub mod virtq;
 pub mod vsock;
 
+mod sealed {
+    pub trait Sealed {}
+}
+
 pub use endian_num::{be128, be16, be32, be64, le128, le16, le32, le64, Be, Le};
 use num_enum::{FromPrimitive, IntoPrimitive, TryFromPrimitive};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,10 @@ pub mod pvirtq;
 pub mod virtq;
 pub mod vsock;
 
+mod sealed {
+    pub trait Sealed {}
+}
+
 pub use endian_num::{Be, Le, be16, be32, be64, be128, le16, le32, le64, le128};
 use num_enum::{FromPrimitive, IntoPrimitive, TryFromPrimitive};
 


### PR DESCRIPTION
When users wanted to be generic over `FeatureBits` before, they had to duplicate the list of non-supertrait where bounds because [only supertrait bounds are elaborated](https://github.com/rust-lang/rust/issues/20671):

```rust
fn foo<T: FeatureBits>(features: T)
where
    virtio::F: From<T> + AsRef<T> + AsMut<T>;
```

This PR removes the not-elaborated where clauses to make generic code less verbose:

```rust
fn foo<T: FeatureBits>(features: T);
```

Of course, if the generic function wants to use some non-elaborated bounds, that is still possible.

`cargo-semver-checks` detects this as a breaking change, but I don't think it actually is. I think it does not handle the fact that `Trait: Supertrait` is equivalent to `Trait where Self: Supertrait`.

Still, we need to do a breaking release anyway because of https://github.com/rust-osdev/virtio-spec-rs/pull/18, so this PR also seals `FeatureBits`. I don't think anyone would want to implement `FeatureBits` outside this crate without the internal helper macros anyway.