### PR TITLE
fix(docsrs): migrate from `doc_auto_cfg` to `doc_cfg`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@
 //! | PMEM Device                       | ❌        |             |
 
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "nightly", feature(allocator_api))]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
`dock_auto_cfg` was merged into `doc_cfg` in https://github.com/rust-lang/rust/pull/138907.