### PR TITLE
fix: upgrade to Rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "virtio-spec"
 version = "0.3.2"
 authors = ["Martin Kröning <mkroening@posteo.net>"]
-edition = "2021"
+edition = "2024"
 description = "Definitions from the Virtual I/O Device (VIRTIO) specification."
 repository = "https://github.com/rust-osdev/virtio-spec-rs"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,10 +109,10 @@ pub mod pvirtq;
 pub mod virtq;
 pub mod vsock;
 
-pub use endian_num::{be128, be16, be32, be64, le128, le16, le32, le64, Be, Le};
+pub use endian_num::{Be, Le, be16, be32, be64, be128, le16, le32, le64, le128};
 use num_enum::{FromPrimitive, IntoPrimitive, TryFromPrimitive};
 
-pub use self::features::{FeatureBits, F};
+pub use self::features::{F, FeatureBits};
 
 virtio_bitflags! {
     /// Device Status Field
@@ -358,10 +358,10 @@ pub trait DeviceConfigSpace: Sized {
     ///
     /// ```rust
     /// # use virtio_spec as virtio;
-    /// use virtio::net::ConfigVolatileFieldAccess;
     /// use virtio::DeviceConfigSpace;
-    /// use volatile::access::ReadOnly;
+    /// use virtio::net::ConfigVolatileFieldAccess;
     /// use volatile::VolatilePtr;
+    /// use volatile::access::ReadOnly;
     ///
     /// fn read_mac(
     ///     common_cfg: VolatilePtr<'_, virtio::pci::CommonCfg, ReadOnly>,

--- a/src/mmio.rs
+++ b/src/mmio.rs
@@ -2,12 +2,12 @@
 
 use core::mem;
 
-use volatile::access::{ReadOnly, ReadWrite, Readable, RestrictAccess, WriteOnly};
 use volatile::VolatilePtr;
+use volatile::access::{ReadOnly, ReadWrite, Readable, RestrictAccess, WriteOnly};
 
 pub use crate::driver_notifications::NotificationData;
 use crate::volatile::{OveralignedVolatilePtr, WideVolatilePtr};
-use crate::{le16, le32, DeviceConfigSpace, DeviceStatus, Id};
+use crate::{DeviceConfigSpace, DeviceStatus, Id, le16, le32};
 
 /// The magic value for virtio-mmio.
 ///

--- a/src/pci.rs
+++ b/src/pci.rs
@@ -3,15 +3,15 @@
 use core::mem;
 
 use num_enum::{FromPrimitive, IntoPrimitive};
-use pci_types::capability::PciCapabilityAddress;
 use pci_types::ConfigRegionAccess;
-use volatile::access::{ReadOnly, ReadWrite, Readable, RestrictAccess};
+use pci_types::capability::PciCapabilityAddress;
 use volatile::VolatilePtr;
+use volatile::access::{ReadOnly, ReadWrite, Readable, RestrictAccess};
 use volatile_macro::VolatileFieldAccess;
 
 pub use crate::driver_notifications::NotificationData;
 use crate::volatile::WideVolatilePtr;
-use crate::{le16, le32, le64, DeviceConfigSpace, DeviceStatus};
+use crate::{DeviceConfigSpace, DeviceStatus, le16, le32, le64};
 
 /// PCI Capability
 ///

--- a/src/pvirtq.rs
+++ b/src/pvirtq.rs
@@ -2,7 +2,7 @@
 
 use bitfield_struct::bitfield;
 
-use crate::{le16, le32, le64, virtq, RingEventFlags};
+use crate::{RingEventFlags, le16, le32, le64, virtq};
 
 /// Packed Virtqueue Descriptor
 #[doc(alias = "pvirtq_desc")]

--- a/src/virtq/mod.rs
+++ b/src/virtq/mod.rs
@@ -4,7 +4,7 @@
 mod alloc;
 
 use core::alloc::Layout;
-use core::ptr::{addr_of_mut, NonNull};
+use core::ptr::{NonNull, addr_of_mut};
 use core::{mem, ptr};
 
 use crate::{le16, le32, le64};

--- a/src/volatile.rs
+++ b/src/volatile.rs
@@ -2,10 +2,10 @@
 
 use core::marker::PhantomData;
 
-use volatile::access::{Readable, Writable};
 use volatile::VolatilePtr;
+use volatile::access::{Readable, Writable};
 
-use crate::{be32, be64, le16, le32, le64, DeviceStatus, Id};
+use crate::{DeviceStatus, Id, be32, be64, le16, le32, le64};
 
 /// A wide volatile pointer for 64-bit fields.
 ///
@@ -295,7 +295,7 @@ impl OveralignedField<le32> for crate::mmio::InterruptStatus {
 }
 
 mod private {
-    use crate::{le16, le32, DeviceStatus, Id};
+    use crate::{DeviceStatus, Id, le16, le32};
 
     pub trait Sealed<T> {}
 


### PR DESCRIPTION
There are only formatting changes from Rust 2024. See [Rustfmt: Raw identifier sorting](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rustfmt-raw-identifier-sorting.html).