### PR TITLE
docs: mark Entropy Device as supported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,27 +61,27 @@
 //!
 //! ## Device Types
 //!
-//! | Device Type                       | Available | Module      |
-//! | --------------------------------- | --------- | ----------- |
-//! | Network Device                    | ✅        | [`net`]     |
-//! | Block Device                      | ❌        |             |
-//! | Console Device                    | ✅        | [`console`] |
-//! | Entropy Device                    | ❌        |             |
-//! | Traditional Memory Balloon Device | ✅        | [`balloon`] |
-//! | SCSI Host Device                  | ❌        |             |
-//! | GPU Device                        | ❌        |             |
-//! | Input Device                      | ❌        |             |
-//! | Crypto Device                     | ❌        |             |
-//! | Socket Device                     | ✅        | [`vsock`]   |
-//! | File System Device                | ✅        | [`fs`]      |
-//! | RPMB Device                       | ❌        |             |
-//! | IOMMU Device                      | ❌        |             |
-//! | Sound Device                      | ❌        |             |
-//! | Memory Device                     | ❌        |             |
-//! | I2C Adapter Device                | ❌        |             |
-//! | SCMI Device                       | ❌        |             |
-//! | GPIO Device                       | ❌        |             |
-//! | PMEM Device                       | ❌        |             |
+//! | Device Type                       | Available | Module        |
+//! | --------------------------------- | --------- | ------------- |
+//! | Network Device                    | ✅        | [`net`]       |
+//! | Block Device                      | ❌        |               |
+//! | Console Device                    | ✅        | [`console`]   |
+//! | Entropy Device                    | ✅        | None required |
+//! | Traditional Memory Balloon Device | ✅        | [`balloon`]   |
+//! | SCSI Host Device                  | ❌        |               |
+//! | GPU Device                        | ❌        |               |
+//! | Input Device                      | ❌        |               |
+//! | Crypto Device                     | ❌        |               |
+//! | Socket Device                     | ✅        | [`vsock`]     |
+//! | File System Device                | ✅        | [`fs`]        |
+//! | RPMB Device                       | ❌        |               |
+//! | IOMMU Device                      | ❌        |               |
+//! | Sound Device                      | ❌        |               |
+//! | Memory Device                     | ❌        |               |
+//! | I2C Adapter Device                | ❌        |               |
+//! | SCMI Device                       | ❌        |               |
+//! | GPIO Device                       | ❌        |               |
+//! | PMEM Device                       | ❌        |               |
 
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
virtio-rng does not require a dedicated module since it does not define any feature bits or a device configuration layout. Still, we have `virtio::Id::Rng` and everything else that is required to drive a virtio-rng device.

Thus, I think it would be fair to say this crate supports virtio-rng devices. I have put a note into the module column that no module is required to run the device.