### PR TITLE
feat: add `DeviceStatus::SUSPEND` from spec 1.4

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,23 +148,23 @@ virtio_bitflags! {
         /// </div>
         const DRIVER = 2;
 
-        /// Indicates that something went wrong in the guest,
-        /// and it has given up on the device. This could be an internal
-        /// error, or the driver didn't like the device for some reason, or
-        /// even a fatal error during device operation.
-        const FAILED = 128;
+        /// Indicates that the driver is set up and ready to
+        /// drive the device.
+        const DRIVER_OK = 4;
 
         /// Indicates that the driver has acknowledged all the
         /// features it understands, and feature negotiation is complete.
         const FEATURES_OK = 8;
 
-        /// Indicates that the driver is set up and ready to
-        /// drive the device.
-        const DRIVER_OK = 4;
-
         /// Indicates that the device has experienced
         /// an error from which it can't recover.
         const DEVICE_NEEDS_RESET = 64;
+
+        /// Indicates that something went wrong in the guest,
+        /// and it has given up on the device. This could be an internal
+        /// error, or the driver didn't like the device for some reason, or
+        /// even a fatal error during device operation.
+        const FAILED = 128;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,10 @@ virtio_bitflags! {
         /// features it understands, and feature negotiation is complete.
         const FEATURES_OK = 8;
 
+        /// When [`virtio::F::SUSPEND`] is negotiated, indicates that the
+        /// device has been suspended by the driver.
+        const SUSPEND = 16;
+
         /// Indicates that the device has experienced
         /// an error from which it can't recover.
         const DEVICE_NEEDS_RESET = 64;


### PR DESCRIPTION
For a spec diff, see https://docs.oasis-open.org/virtio/virtio/v1.4/cs01/virtio-v1.4-cs01-diff-from-v1.2-cs01.html#x1-110001.