### PR TITLE
add feature set of a block device

### DIFF
--- a/src/blk.rs
+++ b/src/blk.rs
@@ -1,0 +1,147 @@
+//! Block Device
+
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use volatile::access::ReadOnly;
+use volatile_macro::VolatileFieldAccess;
+
+pub use super::features::blk::F;
+use crate::{le16, le32, le64};
+
+// Device configuration.
+
+/// Modelled up to `num_queues`; the trailing discard and write-zeroes
+/// parameters follow in the device's configuration space and are never
+/// accessed. The fields in between are modelled even where the driver
+/// ignores them, because a volatile field's offset is its position in this
+/// struct — skipping one would misplace everything after it.
+///
+/// Use `ConfigVolatileFieldAccess` to work with this struct.
+#[doc(alias = "virtio_blk_config")]
+#[cfg_attr(
+    feature = "zerocopy",
+    derive(
+        zerocopy_derive::KnownLayout,
+        zerocopy_derive::Immutable,
+        zerocopy_derive::FromBytes,
+    )
+)]
+#[derive(VolatileFieldAccess)]
+#[repr(C)]
+pub struct Config {
+    /// The capacity of the device, expressed in 512-byte sectors.
+    #[access(ReadOnly)]
+    capacity: le64,
+
+    /// The maximum size of any single segment. Only valid if
+    /// `SIZE_MAX` was negotiated.
+    #[access(ReadOnly)]
+    size_max: le32,
+
+    /// The maximum number of segments in a request. Only valid if
+    /// `SEG_MAX` was negotiated.
+    #[access(ReadOnly)]
+    seg_max: le32,
+
+    /// Cylinders of the device's geometry.
+    #[access(ReadOnly)]
+    cylinders: le16,
+
+    /// Heads of the device's geometry.
+    #[access(ReadOnly)]
+    heads: u8,
+
+    /// Sectors of the device's geometry.
+    #[access(ReadOnly)]
+    sectors: u8,
+
+    /// The optimal I/O size in bytes. Only valid if `BLK_SIZE` was
+    /// negotiated. This is *not* the unit the device addresses, which is
+    /// always `SECTOR_SIZE`.
+    #[access(ReadOnly)]
+    blk_size: le32,
+
+    /// Number of logical blocks per physical block, as a power of two.
+    /// Only valid if `TOPOLOGY` was negotiated.
+    #[access(ReadOnly)]
+    physical_block_exp: u8,
+
+    /// Offset of the first aligned logical block. Only valid if `TOPOLOGY`
+    /// was negotiated.
+    #[access(ReadOnly)]
+    alignment_offset: u8,
+
+    /// Suggested minimum I/O size in blocks. Only valid if `TOPOLOGY` was
+    /// negotiated.
+    #[access(ReadOnly)]
+    min_io_size: le16,
+
+    /// Suggested optimal I/O size in blocks. Only valid if `TOPOLOGY` was
+    /// negotiated.
+    #[access(ReadOnly)]
+    opt_io_size: le32,
+
+    /// Whether the device's cache writes back. Only valid if `CONFIG_WCE`
+    /// was negotiated.
+    #[access(ReadOnly)]
+    writeback: u8,
+
+    #[access(ReadOnly)]
+    unused0: u8,
+
+    /// The number of request virtqueues. Only valid if `MQ` was negotiated;
+    /// the device exposes a single request queue otherwise.
+    #[access(ReadOnly)]
+    num_queues: le16,
+}
+
+/// Request types, the `type` field of the request header.
+#[doc(alias = "VIRTIO_BLK_T")]
+#[derive(IntoPrimitive, TryFromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
+#[non_exhaustive]
+#[repr(u32)]
+pub enum RequestType {
+    #[doc(alias = "VIRTIO_BLK_T_IN")]
+    IN = 0,
+
+    #[doc(alias = "VIRTIO_BLK_T_OUT")]
+    OUT = 1,
+
+    #[doc(alias = "VIRTIO_BLK_T_FLUSH")]
+    FLUSH = 4,
+}
+
+/// The status byte the device writes as the last part of every request.
+#[doc(alias = "VIRTIO_BLK_S")]
+#[derive(IntoPrimitive, TryFromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum Status {
+    #[doc(alias = "VIRTIO_BLK_S_OK")]
+    OK = 0,
+
+    #[doc(alias = "VIRTIO_BLK_S_IOERR")]
+    IOERR = 1,
+
+    #[doc(alias = "VIRTIO_BLK_S_UNSUPP")]
+    UNSUPP = 2,
+}
+
+/// The fixed-size header that starts every request.
+#[doc(alias = "virtio_blk_req")]
+#[derive(Debug)]
+#[repr(C)]
+pub struct RequestHeader {
+    type_: le32,
+    reserved: le32,
+    sector: le64,
+}
+
+impl RequestHeader {
+    pub fn new(type_: RequestType, sector: u64) -> Self {
+        Self {
+            type_: le32::from_ne(type_.into()),
+            reserved: le32::from_ne(0),
+            sector: le64::from_ne(sector),
+        }
+    }
+}

--- a/src/features.rs
+++ b/src/features.rs
@@ -372,6 +372,84 @@ pub mod console {
     impl crate::FeatureBits for F {}
 }
 
+pub mod blk {
+    use crate::le128;
+
+    feature_bits! {
+        /// Block Device Feature Bits
+        #[doc(alias = "VIRTIO_BLK_F")]
+        pub struct F: le128 {
+            /// Maximum size of any single segment is in size_max.
+            #[doc(alias = "VIRTIO_BLK_F_SIZE_MAX")]
+            const SIZE_MAX = 1 << 1;
+
+            /// Maximum number of segments in a request is in seg_max.
+            #[doc(alias = "VIRTIO_BLK_F_SEG_MAX")]
+            const SEG_MAX = 1 << 2;
+
+            /// Disk-style geometry specified in geometry.
+            #[doc(alias = "VIRTIO_BLK_F_GEOMETRY")]
+            const GEOMETRY = 1 << 4;
+
+            /// Device is read-only.
+            #[doc(alias = "VIRTIO_BLK_F_RO")]
+            const RO = 1 << 5;
+
+            /// Block size of disk is in blk_size.
+            #[doc(alias = "VIRTIO_BLK_F_BLK_SIZE")]
+            const BLK_SIZE = 1 << 6;
+
+            /// Cache flush command support.
+            #[doc(alias = "VIRTIO_BLK_F_FLUSH")]
+            const FLUSH = 1 << 9;
+
+            /// Device exports information on optimal I/O alignment.
+            #[doc(alias = "VIRTIO_BLK_F_TOPOLOGY")]
+            const TOPOLOGY = 1 << 10;
+
+            /// Device can toggle its cache between writeback and writethrough modes.
+            #[doc(alias = "VIRTIO_BLK_F_CONFIG_WCE")]
+            const CONFIG_WCE = 1 << 11;
+
+            /// Device supports multiqueue.
+            #[doc(alias = "VIRTIO_BLK_F_MQ")]
+            const MQ = 1 << 12;
+
+            /// Device can support discard command, maximum discard sectors size in
+            /// max_discard_sectors and maximum discard segment number in max_discard_seg.
+            #[doc(alias = "VIRTIO_BLK_F_DISCARD")]
+            const DISCARD = 1 << 13;
+
+            /// Device can support write zeroes command, maximum write zeroes sectors
+            /// size in max_write_zeroes_sectors and maximum write zeroes segment
+            /// number in max_write_zeroes_seg.
+            #[doc(alias = "VIRTIO_BLK_F_WRITE_ZEROES")]
+            const WRITE_ZEROES = 1 << 14;
+
+            /// Device supports providing storage lifetime information.
+            #[doc(alias = "VIRTIO_BLK_F_LIFETIME")]
+            const LIFETIME = 1 << 15;
+
+            /// Device supports secure erase command, maximum erase sectors count
+            /// in max_secure_erase_sectors and maximum erase segment number in
+            /// max_secure_erase_seg.
+            #[doc(alias = "VIRTIO_BLK_F_SECURE_ERASE")]
+            const SECURE_ERASE = 1 << 16;
+
+            /// Device is a Zoned Block Device, that is, a device that follows
+            /// the zoned storage device behavior that is also supported by industry
+            /// standards such as the T10 Zoned Block Command standard (ZBC r05) or
+            /// the NVMe(TM) NVM Express Zoned Namespace Command Set Specification 1.1b (ZNS).
+            /// For brevity, these standard documents are referred as "ZBD standards" from
+            /// this point on in the text.
+            #[doc(alias = "VIRTIO_BLK_F_ZONED")]
+            const ZONED = 1 << 17;
+        }
+    }
+
+    impl crate::FeatureBits for F {}
+}
+
 pub mod net {
     use crate::le128;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //! | Device Type                       | Available | Module        |
 //! | --------------------------------- | --------- | ------------- |
 //! | Network Device                    | ✅        | [`net`]       |
-//! | Block Device                      | ❌        |               |
+//! | Block Device                      | ✅        | [`blk`]       |
 //! | Console Device                    | ✅        | [`console`]   |
 //! | Entropy Device                    | ✅        | None required |
 //! | Traditional Memory Balloon Device | ✅        | [`balloon`]   |
@@ -95,6 +95,7 @@ mod bitflags;
 #[macro_use]
 pub mod volatile;
 pub mod balloon;
+pub mod blk;
 pub mod console;
 #[cfg(any(feature = "mmio", feature = "pci"))]
 mod driver_notifications;


### PR DESCRIPTION
Add structs and constants, which are derived from the specification Virtual I/O Device (VIRTIO)