### PR TITLE
style: remove trailing spaces from doc comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! - `VIRTIO_NET_F_CSUM` from the specification becomes [`virtio::net::F::CSUM`] in this crate.
 //! - `virtio_net_config` from the specification becomes [`virtio::net::Config`] in this crate.
-//!  
+//!
 //! [`virtio::net::F::CSUM`]: net::F::CSUM
 //! [`virtio::net::Config`]: net::Config
 //!


### PR DESCRIPTION
Cherry-picked from @Kreb216's fork.