### PR TITLE
feat: make enums ABI-compatible

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -1,6 +1,6 @@
 //! Console Device
 
-use num_enum::{FromPrimitive, IntoPrimitive};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use volatile::access::ReadOnly;
 use volatile_macro::VolatileFieldAccess;
 
@@ -55,17 +55,8 @@ pub struct Control {
 }
 
 /// Event
-///
-/// <div class="warning">
-///
-/// This enum is not ABI-compatible with it's corresponding field.
-/// Use [`Device::from`] for converting from an integer.
-///
-/// </div>
-///
-/// [`Device::from`]: Device#impl-From<u16>-for-Device
 #[doc(alias = "VIRTIO_CONSOLE")]
-#[derive(IntoPrimitive, FromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(IntoPrimitive, TryFromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum Device {
@@ -121,9 +112,6 @@ pub enum Device {
     /// This control command is immediately followed by the UTF-8 name of the port for identification within the guest (without a NUL terminator).
     #[doc(alias = "VIRTIO_CONSOLE_PORT_NAME")]
     PortName = 7,
-
-    #[num_enum(catch_all)]
-    Unknown(u16),
 }
 
 /// Resize Message Layout

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,6 +1,6 @@
 //! Network Device
 
-use num_enum::{FromPrimitive, IntoPrimitive, TryFromPrimitive};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use volatile::access::ReadOnly;
 use volatile_macro::VolatileFieldAccess;
 
@@ -78,17 +78,8 @@ virtio_bitflags! {
 }
 
 /// Network Device Header GSO Type
-///
-/// <div class="warning">
-///
-/// This enum is not ABI-compatible with it's corresponding field.
-/// Use [`HdrGso::from`] for converting from an integer.
-///
-/// </div>
-///
-/// [`HdrGso::from`]: HdrGso#impl-From<u8>-for-HdrGso
 #[doc(alias = "VIRTIO_NET_HDR_GSO")]
-#[derive(IntoPrimitive, FromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(IntoPrimitive, TryFromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum HdrGso {
@@ -109,9 +100,6 @@ pub enum HdrGso {
 
     #[doc(alias = "VIRTIO_NET_HDR_GSO_ECN")]
     Ecn = 0x80,
-
-    #[num_enum(catch_all)]
-    Unknown(u8),
 }
 
 /// Network Device Header
@@ -195,17 +183,8 @@ endian_bitflags! {
 }
 
 /// Hash Report
-///
-/// <div class="warning">
-///
-/// This enum is not ABI-compatible with it's corresponding field.
-/// Use [`HashReport::from`] for converting from an integer.
-///
-/// </div>
-///
-/// [`HashReport::from`]: HashReport#impl-From<u16>-for-HashReport
 #[doc(alias = "VIRTIO_NET_HASH_REPORT")]
-#[derive(IntoPrimitive, FromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(IntoPrimitive, TryFromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum HashReport {
@@ -238,9 +217,6 @@ pub enum HashReport {
 
     #[doc(alias = "VIRTIO_NET_HASH_REPORT_UDPv6_EX")]
     Udpv6Ex = 9,
-
-    #[num_enum(catch_all)]
-    Unknown(u16),
 }
 
 /// Command class


### PR DESCRIPTION
I believe implementing [`TryFromPrimitive`](https://docs.rs/num_enum/0.7.6/num_enum/trait.TryFromPrimitive.html), which also returns the original number in the error case, is more useful than having `Unknown` catch-all variants for all enums.

This also makes the types ABI-compatible, which is still to be used with care when using foreign data, but that is how all Rust enums work until we have [unnamed enum variants](https://github.com/rust-lang/rfcs/pull/3894).