### PR TITLE
feat: don't derive zerocopy traits for volatile structs

### DIFF
--- a/src/balloon.rs
+++ b/src/balloon.rs
@@ -8,14 +8,6 @@ use crate::le32;
 ///
 /// Use [`ConfigVolatileFieldAccess`] to work with this struct.
 #[doc(alias = "virtio_balloon_config")]
-#[cfg_attr(
-    feature = "zerocopy",
-    derive(
-        zerocopy_derive::KnownLayout,
-        zerocopy_derive::Immutable,
-        zerocopy_derive::FromBytes,
-    )
-)]
 #[derive(VolatileFieldAccess)]
 #[repr(C)]
 pub struct Config {

--- a/src/console.rs
+++ b/src/console.rs
@@ -11,14 +11,6 @@ use crate::{le16, le32};
 ///
 /// Use [`ConfigVolatileFieldAccess`] to work with this struct.
 #[doc(alias = "virtio_console_config")]
-#[cfg_attr(
-    feature = "zerocopy",
-    derive(
-        zerocopy_derive::KnownLayout,
-        zerocopy_derive::Immutable,
-        zerocopy_derive::FromBytes,
-    )
-)]
 #[derive(VolatileFieldAccess)]
 #[repr(C)]
 pub struct Config {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -10,14 +10,6 @@ use super::le32;
 ///
 /// Use [`ConfigVolatileFieldAccess`] to work with this struct.
 #[doc(alias = "virtio_fs_config")]
-#[cfg_attr(
-    feature = "zerocopy",
-    derive(
-        zerocopy_derive::KnownLayout,
-        zerocopy_derive::Immutable,
-        zerocopy_derive::FromBytes,
-    )
-)]
 #[derive(VolatileFieldAccess)]
 #[repr(C)]
 pub struct Config {

--- a/src/net.rs
+++ b/src/net.rs
@@ -23,14 +23,6 @@ endian_bitflags! {
 ///
 /// Use [`ConfigVolatileFieldAccess`] to work with this struct.
 #[doc(alias = "virtio_net_config")]
-#[cfg_attr(
-    feature = "zerocopy",
-    derive(
-        zerocopy_derive::KnownLayout,
-        zerocopy_derive::Immutable,
-        zerocopy_derive::FromBytes,
-    )
-)]
 #[derive(VolatileFieldAccess)]
 #[repr(C)]
 pub struct Config {

--- a/src/pci.rs
+++ b/src/pci.rs
@@ -327,14 +327,6 @@ pub enum CapCfgType {
 ///
 /// Use [`CommonCfgVolatileFieldAccess`] and [`CommonCfgVolatileWideFieldAccess`] to work with this struct.
 #[doc(alias = "virtio_pci_common_cfg")]
-#[cfg_attr(
-    feature = "zerocopy",
-    derive(
-        zerocopy_derive::KnownLayout,
-        zerocopy_derive::Immutable,
-        zerocopy_derive::FromBytes,
-    )
-)]
 #[derive(VolatileFieldAccess)]
 #[repr(C)]
 pub struct CommonCfg {

--- a/src/vsock.rs
+++ b/src/vsock.rs
@@ -11,14 +11,6 @@ use crate::le64;
 ///
 /// Use [`ConfigVolatileFieldAccess`] to work with this struct.
 #[doc(alias = "virtio_vsock_config")]
-#[cfg_attr(
-    feature = "zerocopy",
-    derive(
-        zerocopy_derive::KnownLayout,
-        zerocopy_derive::Immutable,
-        zerocopy_derive::FromBytes,
-    )
-)]
 #[derive(VolatileFieldAccess)]
 #[repr(C)]
 pub struct Config {


### PR DESCRIPTION
Since volatile structs are likely never in byte slices and only behind volatile pointers, deriving zerocopy traits does not make sense for them.