### PR TITLE
feat: add virtio-blk definitions

### DIFF
--- a/src/blk.rs
+++ b/src/blk.rs
@@ -1,0 +1,373 @@
+//! Block Device
+
+use bitfield_struct::bitfield;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use volatile::access::ReadOnly;
+use volatile_macro::VolatileFieldAccess;
+
+pub use super::features::blk::F;
+use crate::{le16, le32, le64};
+
+/// Block Device Configuration Layout
+///
+/// Use [`ConfigVolatileFieldAccess`] to work with this struct.
+#[doc(alias = "virtio_blk_config")]
+#[derive(VolatileFieldAccess)]
+#[repr(C)]
+pub struct Config {
+    #[access(ReadOnly)]
+    capacity: le64,
+
+    #[access(ReadOnly)]
+    size_max: le32,
+
+    #[access(ReadOnly)]
+    seg_max: le32,
+
+    #[access(ReadOnly)]
+    geometry: Geometry,
+
+    #[access(ReadOnly)]
+    blk_size: le32,
+
+    #[access(ReadOnly)]
+    topology: Topology,
+
+    #[access(ReadOnly)]
+    writeback: u8,
+
+    #[access(ReadOnly)]
+    unused0: u8,
+
+    #[access(ReadOnly)]
+    num_queues: u8,
+
+    #[access(ReadOnly)]
+    max_discard_sectors: le32,
+
+    #[access(ReadOnly)]
+    max_discard_seg: le32,
+
+    #[access(ReadOnly)]
+    discard_sector_alignment: le32,
+
+    #[access(ReadOnly)]
+    max_write_zeroes_sectors: le32,
+
+    #[access(ReadOnly)]
+    max_write_zeroes_seg: le32,
+
+    #[access(ReadOnly)]
+    write_zeroes_may_unmap: u8,
+
+    #[access(ReadOnly)]
+    unused1: [u8; 3],
+
+    #[access(ReadOnly)]
+    max_secure_erase_sectors: le32,
+
+    #[access(ReadOnly)]
+    max_secure_erase_seg: le32,
+
+    #[access(ReadOnly)]
+    secure_erase_sector_alignment: le32,
+
+    #[access(ReadOnly)]
+    zoned: ZonedCharacteristics,
+}
+
+/// Disk-style geometry.
+#[doc(alias = "virtio_blk_geometry")]
+#[derive(VolatileFieldAccess)]
+#[repr(C)]
+pub struct Geometry {
+    #[access(ReadOnly)]
+    cylinders: le16,
+
+    #[access(ReadOnly)]
+    heads: u8,
+
+    #[access(ReadOnly)]
+    sectors: u8,
+}
+
+/// Block device topology.
+#[doc(alias = "virtio_blk_topology")]
+#[derive(VolatileFieldAccess)]
+#[repr(C)]
+pub struct Topology {
+    /// # of logical blocks per physical block (log2)
+    #[access(ReadOnly)]
+    physical_block_exp: u8,
+
+    /// offset of first aligned logical block
+    #[access(ReadOnly)]
+    alignment_offset: u8,
+
+    /// suggested minimum I/O size in blocks
+    #[access(ReadOnly)]
+    min_io_size: le16,
+
+    /// optimal (suggested maximum) I/O size in blocks
+    #[access(ReadOnly)]
+    opt_io_size: le32,
+}
+
+#[doc(alias = "virtio_blk_zoned_characteristics")]
+#[derive(VolatileFieldAccess)]
+#[repr(C)]
+pub struct ZonedCharacteristics {
+    #[access(ReadOnly)]
+    zone_sectors: le32,
+
+    #[access(ReadOnly)]
+    max_open_zones: le32,
+
+    #[access(ReadOnly)]
+    max_active_zones: le32,
+
+    #[access(ReadOnly)]
+    max_append_sectors: le32,
+
+    #[access(ReadOnly)]
+    write_granularity: le32,
+
+    #[access(ReadOnly)]
+    model: u8,
+
+    #[access(ReadOnly)]
+    unused2: [u8; 3],
+}
+
+/// A zoning model.
+#[doc(alias = "VIRTIO_BLK_Z")]
+#[derive(IntoPrimitive, TryFromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum Z {
+    #[doc(alias = "VIRTIO_BLK_Z_NONE")]
+    None = 0,
+
+    #[doc(alias = "VIRTIO_BLK_Z_HM")]
+    Hm = 1,
+
+    #[doc(alias = "VIRTIO_BLK_Z_HA")]
+    Ha = 2,
+}
+
+/// The type of a request.
+#[doc(alias = "VIRTIO_BLK_T")]
+#[derive(IntoPrimitive, TryFromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
+#[non_exhaustive]
+#[repr(u32)]
+pub enum T {
+    #[doc(alias = "VIRTIO_BLK_T_IN")]
+    In = 0,
+
+    #[doc(alias = "VIRTIO_BLK_T_OUT")]
+    Out = 1,
+
+    #[doc(alias = "VIRTIO_BLK_T_FLUSH")]
+    Flush = 4,
+
+    #[doc(alias = "VIRTIO_BLK_T_GET_ID")]
+    GetId = 8,
+
+    #[doc(alias = "VIRTIO_BLK_T_GET_LIFETIME")]
+    GetLifetime = 10,
+
+    #[doc(alias = "VIRTIO_BLK_T_DISCARD")]
+    Discard = 11,
+
+    #[doc(alias = "VIRTIO_BLK_T_WRITE_ZEROES")]
+    WriteZeroes = 13,
+
+    #[doc(alias = "VIRTIO_BLK_T_SECURE_ERASE")]
+    SecureErase = 14,
+
+    #[doc(alias = "VIRTIO_BLK_T_ZONE_APPEND")]
+    ZoneAppend = 15,
+
+    #[doc(alias = "VIRTIO_BLK_T_ZONE_REPORT")]
+    ZoneReport = 16,
+
+    #[doc(alias = "VIRTIO_BLK_T_ZONE_OPEN")]
+    ZoneOpen = 18,
+
+    #[doc(alias = "VIRTIO_BLK_T_ZONE_CLOSE")]
+    ZoneClose = 20,
+
+    #[doc(alias = "VIRTIO_BLK_T_ZONE_FINISH")]
+    ZoneFinish = 22,
+
+    #[doc(alias = "VIRTIO_BLK_T_ZONE_RESET")]
+    ZoneReset = 24,
+
+    #[doc(alias = "VIRTIO_BLK_T_ZONE_RESET_ALL")]
+    ZoneResetAll = 26,
+}
+
+/// A segment for discard, secure erase or write zeroes.
+#[doc(alias = "virtio_blk_discard_write_zeroes")]
+#[cfg_attr(
+    feature = "zerocopy",
+    derive(
+        zerocopy_derive::KnownLayout,
+        zerocopy_derive::Immutable,
+        zerocopy_derive::FromBytes,
+        zerocopy_derive::IntoBytes,
+    )
+)]
+#[repr(C)]
+pub struct DiscardWriteZeroes {
+    pub sector: le64,
+    pub num_sectors: le32,
+    pub flags: le32,
+}
+
+/// The flags of a [`DiscardWriteZeroes`] segment.
+#[bitfield(u32, repr = le32, from = le32::from_ne, into = le32::to_ne)]
+pub struct DiscardWriteZeroesFlags {
+    #[bits(1)]
+    pub unmap: bool,
+
+    #[bits(31)]
+    pub reserved: u32,
+}
+
+/// Lifetime data populated by the device.
+#[doc(alias = "virtio_blk_lifetime")]
+#[cfg_attr(
+    feature = "zerocopy",
+    derive(
+        zerocopy_derive::KnownLayout,
+        zerocopy_derive::Immutable,
+        zerocopy_derive::FromBytes,
+        zerocopy_derive::IntoBytes,
+    )
+)]
+#[repr(C)]
+pub struct Lifetime {
+    pub pre_eol_info: le16,
+    pub device_lifetime_est_typ_a: le16,
+    pub device_lifetime_est_typ_b: le16,
+}
+
+/// End-of-life information.
+#[doc(alias = "VIRTIO_BLK_PRE_EOL_INFO")]
+#[derive(IntoPrimitive, TryFromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
+#[non_exhaustive]
+#[repr(u16)]
+pub enum PreEolInfo {
+    /// Value not available
+    #[doc(alias = "VIRTIO_BLK_PRE_EOL_INFO_UNDEFINED")]
+    Undefined = 0,
+
+    /// < 80% of reserved blocks are consumed
+    #[doc(alias = "VIRTIO_BLK_PRE_EOL_INFO_NORMAL")]
+    Normal = 1,
+
+    /// 80% of reserved blocks are consumed
+    #[doc(alias = "VIRTIO_BLK_PRE_EOL_INFO_WARNING")]
+    Warning = 2,
+
+    /// 90% of reserved blocks are consumed
+    #[doc(alias = "VIRTIO_BLK_PRE_EOL_INFO_URGENT")]
+    Urgent = 3,
+}
+
+/// A status byte.
+#[doc(alias = "VIRTIO_BLK_S")]
+#[derive(IntoPrimitive, TryFromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum S {
+    #[doc(alias = "VIRTIO_BLK_S_OK")]
+    Ok = 0,
+
+    #[doc(alias = "VIRTIO_BLK_S_IOERR")]
+    Ioerr = 1,
+
+    #[doc(alias = "VIRTIO_BLK_S_UNSUPP")]
+    Unsupp = 2,
+
+    #[doc(alias = "VIRTIO_BLK_S_ZONE_INVALID_CMD")]
+    ZoneInvalidCmd = 3,
+
+    #[doc(alias = "VIRTIO_BLK_S_ZONE_UNALIGNED_WP")]
+    ZoneUnalignedWp = 4,
+
+    #[doc(alias = "VIRTIO_BLK_S_ZONE_OPEN_RESOURCE")]
+    ZoneOpenResource = 5,
+
+    #[doc(alias = "VIRTIO_BLK_S_ZONE_ACTIVE_RESOURCE")]
+    ZoneActiveResource = 6,
+}
+
+/// A zone descriptor.
+#[doc(alias = "virtio_blk_zone_descriptor")]
+#[cfg_attr(
+    feature = "zerocopy",
+    derive(
+        zerocopy_derive::KnownLayout,
+        zerocopy_derive::Immutable,
+        zerocopy_derive::FromBytes,
+        zerocopy_derive::IntoBytes,
+    )
+)]
+#[repr(C)]
+pub struct ZoneDescriptor {
+    z_cap: le64,
+    z_start: le64,
+    z_wp: le64,
+    z_type: u8,
+    z_state: u8,
+    reserved: [u8; 38],
+}
+
+/// A zone type.
+#[doc(alias = "VIRTIO_BLK_ZT")]
+#[derive(IntoPrimitive, TryFromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum Zt {
+    #[doc(alias = "VIRTIO_BLK_ZT_CONV")]
+    Conv = 1,
+
+    #[doc(alias = "VIRTIO_BLK_ZT_SWR")]
+    Swr = 2,
+
+    #[doc(alias = "VIRTIO_BLK_ZT_SWP")]
+    Swp = 3,
+}
+
+/// A zone state.
+#[doc(alias = "VIRTIO_BLK_ZS")]
+#[derive(IntoPrimitive, TryFromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum Zs {
+    #[doc(alias = "VIRTIO_BLK_ZS_NOT_WP")]
+    NotWp = 0,
+
+    #[doc(alias = "VIRTIO_BLK_ZS_EMPTY")]
+    Empty = 1,
+
+    #[doc(alias = "VIRTIO_BLK_ZS_IOPEN")]
+    Iopen = 2,
+
+    #[doc(alias = "VIRTIO_BLK_ZS_EOPEN")]
+    Eopen = 3,
+
+    #[doc(alias = "VIRTIO_BLK_ZS_CLOSED")]
+    Closed = 4,
+
+    #[doc(alias = "VIRTIO_BLK_ZS_RDONLY")]
+    Rdonly = 13,
+
+    #[doc(alias = "VIRTIO_BLK_ZS_FULL")]
+    Full = 14,
+
+    #[doc(alias = "VIRTIO_BLK_ZS_OFFLINE")]
+    Offline = 15,
+}

--- a/src/features.rs
+++ b/src/features.rs
@@ -372,6 +372,91 @@ pub mod console {
     impl crate::FeatureBits for F {}
 }
 
+pub mod blk {
+    use crate::le128;
+
+    feature_bits! {
+        /// Block Device Feature Bits
+        #[doc(alias = "VIRTIO_BLK_F")]
+        pub struct F: le128 {
+            /// Maximum size of any single segment is
+            // in `size_max`.
+            #[doc(alias = "VIRTIO_BLK_F_SIZE_MAX")]
+            const SIZE_MAX = 1 << 1;
+
+            /// Maximum number of segments in a
+            /// request is in `seg_max`.
+            #[doc(alias = "VIRTIO_BLK_F_SEG_MAX")]
+            const SEG_MAX = 1 << 2;
+
+            /// Disk-style geometry specified in
+            /// `geometry`.
+            #[doc(alias = "VIRTIO_BLK_F_GEOMETRY")]
+            const GEOMETRY = 1 << 4;
+
+            /// Device is read-only.
+            #[doc(alias = "VIRTIO_BLK_F_RO")]
+            const RO = 1 << 5;
+
+            /// Block size of disk is in `blk_size`.
+            #[doc(alias = "VIRTIO_BLK_F_BLK_SIZE")]
+            const BLK_SIZE = 1 << 6;
+
+            /// Cache flush command support.
+            #[doc(alias = "VIRTIO_BLK_F_FLUSH")]
+            const FLUSH = 1 << 9;
+
+            /// Device exports information on optimal I/O
+            /// alignment.
+            #[doc(alias = "VIRTIO_BLK_F_TOPOLOGY")]
+            const TOPOLOGY = 1 << 10;
+
+            /// Device can toggle its cache between writeback
+            /// and writethrough modes.
+            #[doc(alias = "VIRTIO_BLK_F_CONFIG_WCE")]
+            const CONFIG_WCE = 1 << 11;
+
+            /// Device supports multiqueue.
+            #[doc(alias = "VIRTIO_BLK_F_MQ")]
+            const MQ = 1 << 12;
+
+            /// Device can support discard command, maximum
+            /// discard sectors size in `max_discard_sectors` and maximum discard
+            /// segment number in `max_discard_seg`.
+            #[doc(alias = "VIRTIO_BLK_F_DISCARD")]
+            const DISCARD = 1 << 13;
+
+            /// Device can support write zeroes command,
+            /// maximum write zeroes sectors size in `max_write_zeroes_sectors` and
+            /// maximum write zeroes segment number in `max_write_zeroes_seg`.
+            #[doc(alias = "VIRTIO_BLK_F_WRITE_ZEROES")]
+            const WRITE_ZEROES = 1 << 14;
+
+            /// Device supports providing storage lifetime
+            /// information.
+            #[doc(alias = "VIRTIO_BLK_F_LIFETIME")]
+            const LIFETIME = 1 << 15;
+
+            /// Device supports secure erase command,
+            /// maximum erase sectors count in `max_secure_erase_sectors` and
+            /// maximum erase segment number in `max_secure_erase_seg`.
+            #[doc(alias = "VIRTIO_BLK_F_SECURE_ERASE")]
+            const SECURE_ERASE = 1 << 16;
+
+            /// Device is a Zoned Block Device, that is, a device
+            /// that follows the zoned storage device behavior that is also supported by
+            /// industry standards such as the T10 Zoned Block Command standard (ZBC r05) or
+            /// the NVMe(TM) NVM Express Zoned Namespace Command Set Specification 1.1b
+            /// (ZNS). For brevity, these standard documents are referred as "ZBD standards"
+            /// from this point on in the text.
+            #[doc(alias = "VIRTIO_BLK_F_ZONED")]
+            const ZONED = 1 << 17;
+        }
+    }
+
+    impl crate::FeatureBits for F {}
+}
+
 pub mod net {
     use crate::le128;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //! | Device Type                       | Available | Module        |
 //! | --------------------------------- | --------- | ------------- |
 //! | Network Device                    | ✅        | [`net`]       |
-//! | Block Device                      | ❌        |               |
+//! | Block Device                      | ✅        | [`blk`]       |
 //! | Console Device                    | ✅        | [`console`]   |
 //! | Entropy Device                    | ✅        | None required |
 //! | Traditional Memory Balloon Device | ✅        | [`balloon`]   |
@@ -95,6 +95,7 @@ mod bitflags;
 #[macro_use]
 pub mod volatile;
 pub mod balloon;
+pub mod blk;
 pub mod console;
 #[cfg(any(feature = "mmio", feature = "pci"))]
 mod driver_notifications;


### PR DESCRIPTION
This PR adds the virtio-blk definitions. This is a combination of https://github.com/Kreb216/virtio-spec-rs/commit/3f41c1eeef6514c01dea431c8e3c142d906adae3 and https://github.com/stlankes/virtio-spec-rs/commit/94d7608884052f55d0ee869fb6b274d20f14853f.

I have reworked the code to adhere to the style and naming conventions of this project. I have also added more definitions. I have tested this with the driver of @Kreb216 and the driver of @stlankes and both compile after adjusting a few names.

I have removed `RequestHeader` from @stlankes. Ideally, we would have a `virtio::blk::Req` struct corresponding to the definition in the spec:

```c
struct virtio_blk_req { 
        le32 type; 
        le32 reserved; 
        le64 sector; 
        u8 data[]; 
        u8 status; 
};
```

I did model this, and it works well from a Rust type perspective, but the first three fields and the last one are written by the driver, and the data is written by the device, though. This requires having three descriptors for one type, which does not work in the Hermit driver at the moment. Since it should be possible in principle, though, I would like to keep any implementation-specific helper types such as a header out of this project. It works fine to define the type in the Hermit driver, though.

@Kreb216, I cannot request a review from you through GitHub, but you are welcome to give this a try and leave comments if you have any. :)

This PR does not conflict with, but depends on, the following PRs:
- https://github.com/rust-osdev/virtio-spec-rs/pull/30
- https://github.com/rust-osdev/virtio-spec-rs/pull/31

Closes https://github.com/rust-osdev/virtio-spec-rs/pull/28.