### PR TITLE
feat(net): upgrade to spec 1.4

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -60,6 +60,9 @@ pub struct Config {
 
     #[access(ReadOnly)]
     supported_hash_types: le32,
+
+    #[access(ReadOnly)]
+    supported_tunnel_types: le32,
 }
 
 virtio_bitflags! {
@@ -74,6 +77,18 @@ virtio_bitflags! {
 
         #[doc(alias = "VIRTIO_NET_HDR_F_RSC_INFO")]
         const RSC_INFO = 4;
+
+        #[doc(alias = "VIRTIO_NET_HDR_F_UDP_TUNNEL_CSUM")]
+        const UDP_TUNNEL_CSUM = 8;
+
+        #[doc(alias = "VIRTIO_NET_HDR_F_SECURITY")]
+        const SECURITY = 16;
+
+        #[doc(alias = "VIRTIO_NET_HDR_F_SECURITY_ERR")]
+        const SECURITY_ERR = 32;
+
+        #[doc(alias = "VIRTIO_NET_HDR_F_SECURITY_SA_SOFT_EXPIRY_WARN")]
+        const SECURITY_SA_SOFT_EXPIRY_WARN = 64;
     }
 }
 
@@ -106,6 +121,12 @@ pub enum HdrGso {
 
     #[doc(alias = "VIRTIO_NET_HDR_GSO_UDP_L4")]
     UdpL4 = 5,
+
+    #[doc(alias = "VIRTIO_NET_HDR_GSO_UDP_TUNNEL_IPV4")]
+    UdpTunnelIpv4 = 0x20,
+
+    #[doc(alias = "VIRTIO_NET_HDR_GSO_UDP_TUNNEL_IPV6")]
+    UdpTunnelIpv6 = 0x40,
 
     #[doc(alias = "VIRTIO_NET_HDR_GSO_ECN")]
     Ecn = 0x80,
@@ -157,6 +178,47 @@ pub struct HdrHash {
     pub hash_value: le32,
     pub hash_report: le16,
     pub padding_reserved: le16,
+}
+
+/// Network Device Header with Hash and Tunnel info
+///
+/// Only if VIRTIO_NET_F_HOST_UDP_TUNNEL_GSO or VIRTIO_NET_F_GUEST_UDP_TUNNEL_GSO negotiated
+#[doc(alias = "virtio_net_hdr_hash_tunnel")]
+#[cfg_attr(
+    feature = "zerocopy",
+    derive(
+        zerocopy_derive::KnownLayout,
+        zerocopy_derive::Immutable,
+        zerocopy_derive::FromBytes,
+        zerocopy_derive::IntoBytes,
+    )
+)]
+#[derive(Default, Clone, Copy, Debug)]
+#[repr(C)]
+pub struct HdrHashTunnel {
+    pub hash_hdr: HdrHash,
+    pub outer_th_offset: le16,
+    pub inner_nh_offset: le16,
+}
+
+/// Network Device Header with Hash, Tunnel, and Outer Network info
+///
+/// Only if VIRTIO_NET_F_OUT_NET_HEADER negotiated
+#[doc(alias = "virtio_net_hdr_hash_tunnel_out_net_hdr")]
+#[cfg_attr(
+    feature = "zerocopy",
+    derive(
+        zerocopy_derive::KnownLayout,
+        zerocopy_derive::Immutable,
+        zerocopy_derive::FromBytes,
+        zerocopy_derive::IntoBytes,
+    )
+)]
+#[derive(Default, Clone, Copy, Debug)]
+#[repr(C)]
+pub struct HdrHashTunnelOutNetHdr {
+    pub outer_nh_offset: le16,
+    pub padding_reserved_2: [u8; 6],
 }
 
 endian_bitflags! {

--- a/src/net.rs
+++ b/src/net.rs
@@ -137,10 +137,10 @@ pub struct Hdr {
     pub num_buffers: le16,
 }
 
-/// Network Device Header Hash Report
+/// Network Device Header with Hash Info
 ///
 /// Only if VIRTIO_NET_F_HASH_REPORT negotiated
-#[doc(alias = "virtio_net_hdr")]
+#[doc(alias = "virtio_net_hdr_hash")]
 #[cfg_attr(
     feature = "zerocopy",
     derive(
@@ -152,12 +152,10 @@ pub struct Hdr {
 )]
 #[derive(Default, Clone, Copy, Debug)]
 #[repr(C)]
-pub struct HdrHashReport {
-    /// Only if VIRTIO_NET_F_HASH_REPORT negotiated
+pub struct HdrHash {
+    pub hdr: Hdr,
     pub hash_value: le32,
-    /// Only if VIRTIO_NET_F_HASH_REPORT negotiated
     pub hash_report: le16,
-    /// Only if VIRTIO_NET_F_HASH_REPORT negotiated
     pub padding_reserved: le16,
 }
 


### PR DESCRIPTION
See the spec diff: https://docs.oasis-open.org/virtio/virtio/v1.4/cs01/virtio-v1.4-cs01-diff-from-v1.2-cs01.html#x1-2700001

This also reworks the `virtio::net::Hdr` supersets to be easily composable.