### PR TITLE
chore(Cargo.toml): Remove deprecated `package.authors` field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "virtio-spec"
 version = "0.3.2"
-authors = ["Martin Kröning <mkroening@posteo.net>"]
 edition = "2024"
 description = "Definitions from the Virtual I/O Device (VIRTIO) specification."
 repository = "https://github.com/rust-osdev/virtio-spec-rs"


### PR DESCRIPTION
`package.authors` was deprecated in https://github.com/rust-lang/cargo/pull/15068 and is listed as deprecated in the docs: [The Manifest Format - The Cargo Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field)

Also see:
- https://github.com/hermit-os/hermit-rs/pull/1063